### PR TITLE
Minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are 2 types of playable characters :
 - The game dynamics are based on the interactions between the foxes and the chickens.
 - Chickens NFTs can be staked to generate $EGGS each day, but when they try to sell their $EGGS, there is a 50% chance that the accumulated $EGGS gets stolen by a Wolf.
 - Additionally, a 20% tax is charged on sold $EGGS and distributed to the foxes NFTs holders.
-  Foxes automatically earn 20% of all the $EGGS sold by the chickens and also have a 10% chance of stealing new mints. The rarity of the fox increases the holder's chance of stealing a new mint.
+  Foxes automatically earn 20% of all the $EGGS sold by the chickens. The rarity of the fox increases the holder's chance of stealing a new mint.
 
 ## Contracts
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ document covers gen1 and gen2 features as this is our priority.
 In order to play the game, the player must mint an NFT.
 There are 2 types of playable characters :
 
-- Chickens (90% chance to mint)
-- Foxes (10% chance to mint)
+- Chickens (80% chance to mint)
+- Foxes (20% chance to mint)
 
 ## On gen1, the supply is 15,000 units :
 

--- a/factory/lib.rs
+++ b/factory/lib.rs
@@ -97,16 +97,16 @@ mod factory {
             let mut source = random::default(self.env().block_timestamp());
             let caller = self.env().caller();
             let random_number = source.read::<u64>() % 10000 + 1;
-            // Generates a random number and places chances for 90% against 10%
-            if random_number >= 1 && random_number < 9000 {
-                // 1 to 9000 range targets chicken
+            // Generates a random number and places chances for 80% against 20%
+            if random_number >= 1 && random_number < 8000 {
+                // 1 to 8000 range targets chicken
                 if self.mint_chicken(caller).is_err() {
                     return Err(FactoryError::FailedMint);
                 }
                 self.last_mint.insert(caller, &0);
             }
             else {
-                // 9000 to 10000 range targets fox
+                // 8000 to 10000 range targets fox
                 if self.mint_fox(caller).is_err() {
                     return Err(FactoryError::FailedMint);
                 }


### PR DESCRIPTION
- 80% to 20% chances for chickens and foxes mints.
- Remove doc for foxes stealing mints (a 10% chance) - they don't have to steal them.